### PR TITLE
refactor: track intelligent engine per player

### DIFF
--- a/src/main/java/com/example/pvpenhancer/IntelligentEngine.java
+++ b/src/main/java/com/example/pvpenhancer/IntelligentEngine.java
@@ -10,6 +10,10 @@ import org.bukkit.util.Vector;
 
 import java.util.Locale;
 
+/**
+ * Computes knockback behavior for a single player.
+ * Instances of this engine are managed per-player by the plugin.
+ */
 public class IntelligentEngine {
 
     public enum Mode { AUTO, HIKABRAIN, ARENA }


### PR DESCRIPTION
## Summary
- maintain a per-player `IntelligentEngine` map in `PvPEnhancerPlugin`
- initialize and clean up engine instances with player join/quit events
- retrieve the victim's engine dynamically in damage handling

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_689da22ea6c0832484c374253b09f4aa