### PR TITLE
[IA-REFACTOR-4] Add game mode API and context-aware scaling

### DIFF
--- a/src/main/java/com/example/pvpenhancer/IntelligentEngine.java
+++ b/src/main/java/com/example/pvpenhancer/IntelligentEngine.java
@@ -28,6 +28,8 @@ public class IntelligentEngine {
     private final PvPEnhancerPlugin plugin;
     private Profile smooth;
 
+    private String currentGameMode = "DEFAULT";
+
     // detector (unused for now but kept for future balancing)
     private int belowAirCheck = 4;
     private double hitWeightNearVoid = 2.0;
@@ -74,6 +76,14 @@ public class IntelligentEngine {
         this.decayPerSecond = c.getDouble("intelligent-kb.detector.decay-per-second", 1.0);
     }
 
+    public void setCurrentGamemode(String mode) {
+        if (mode == null || mode.isEmpty()) {
+            this.currentGameMode = "DEFAULT";
+        } else {
+            this.currentGameMode = mode.toUpperCase(Locale.ROOT);
+        }
+    }
+
     private void applyEma(Profile target, double alpha) {
         if (smooth == null) smooth = new Profile();
         smooth.baseH    = smooth.baseH    + alpha * (target.baseH    - smooth.baseH);
@@ -89,11 +99,27 @@ public class IntelligentEngine {
     private void updateKnockbackProfile() {
         Profile target = new Profile();
 
+        double scalingFactor = 1.0;
+        switch (this.currentGameMode) {
+            case "FACTION":
+                scalingFactor = 0.25;
+                break;
+            case "HIKABRAIN":
+                scalingFactor = 0.5;
+                break;
+            case "DUEL":
+            case "TRAINING":
+                scalingFactor = 1.2;
+                break;
+            default:
+                break;
+        }
+
         double acc = accuracyRatio / 100.0;
-        double baseHModifier = 1.0 - ((acc - 0.5) * 0.1); // -5% to +5%
+        double baseHModifier = 1.0 - ((acc - 0.5) * 0.1 * scalingFactor); // -5% to +5%
         target.baseH = NEUTRAL_BASE_H * baseHModifier;
 
-        double baseVModifier = 1.0 + (Math.min(currentCombo, 10) * 0.01); // +0% to +10%
+        double baseVModifier = 1.0 + (Math.min(currentCombo, 10) * 0.01 * scalingFactor); // +0% to +10%
         target.baseV = NEUTRAL_BASE_V * baseVModifier;
 
         target.minY = NEUTRAL_MIN_Y;

--- a/src/main/java/com/example/pvpenhancer/PvpCommand.java
+++ b/src/main/java/com/example/pvpenhancer/PvpCommand.java
@@ -1,10 +1,12 @@
 package com.example.pvpenhancer;
 
+import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.TabCompleter;
+import org.bukkit.entity.Player;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -25,7 +27,7 @@ public class PvpCommand implements CommandExecutor, TabCompleter {
         s.sendMessage(ChatColor.GOLD + "=== PvPEnhancer v1.4.0 ===");
         s.sendMessage(ChatColor.YELLOW + "/pvp admin" + ChatColor.GRAY + " - menu admin (ON/OFF + mode AUTO/HIKABRAIN/ARENA)");
         s.sendMessage(ChatColor.YELLOW + "/pvp reload" + ChatColor.GRAY + " - reload config");
-        s.sendMessage(ChatColor.YELLOW + "/pvp mode <auto|hikabrain|arena>" + ChatColor.GRAY + " - force le mode");
+        s.sendMessage(ChatColor.YELLOW + "/pvp mode <joueur> <mode>" + ChatColor.GRAY + " - force le mode d'un joueur");
         s.sendMessage(ChatColor.YELLOW + "/pvp info" + ChatColor.GRAY + " - état courant");
     }
 
@@ -43,10 +45,21 @@ public class PvpCommand implements CommandExecutor, TabCompleter {
                 return true;
             }
             case "mode": {
-                if (!sender.hasPermission("pvpe.admin")) { sender.sendMessage(ChatColor.RED + "Permission pvpe.admin"); return true; }
-                if (args.length < 2) { sender.sendMessage(ChatColor.RED + "Usage: /pvp mode <auto|hikabrain|arena>"); return true; }
-                listener.setIntelligentMode(args[1]);
-                sender.sendMessage(ChatColor.GREEN + "Mode intelligent: " + args[1].toUpperCase());
+                if (!sender.hasPermission("pvpe.admin")) {
+                    sender.sendMessage(ChatColor.RED + "Permission pvpe.admin");
+                    return true;
+                }
+                if (args.length < 3) {
+                    sender.sendMessage(ChatColor.RED + "Usage: /pvp mode <joueur> <mode>");
+                    return true;
+                }
+                Player target = Bukkit.getPlayer(args[1]);
+                if (target == null) {
+                    sender.sendMessage(ChatColor.RED + "Joueur introuvable");
+                    return true;
+                }
+                PvpEnhancerAPI.setPlayerGamemode(target, args[2]);
+                sender.sendMessage(ChatColor.GREEN + "Mode pour " + target.getName() + ": " + args[2].toUpperCase());
                 return true;
             }
             case "info": {
@@ -65,7 +78,14 @@ public class PvpCommand implements CommandExecutor, TabCompleter {
     @Override
     public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
         if (args.length == 1) return Arrays.asList("help","admin","reload","mode","info");
-        if (args.length == 2 && args[0].equalsIgnoreCase("mode")) return Arrays.asList("auto","hikabrain","arena");
+        if (args.length == 2 && args[0].equalsIgnoreCase("mode")) {
+            List<String> names = new ArrayList<>();
+            for (Player p : Bukkit.getOnlinePlayers()) names.add(p.getName());
+            return names;
+        }
+        if (args.length == 3 && args[0].equalsIgnoreCase("mode")) {
+            return Arrays.asList("FACTION", "HIKABRAIN", "DUEL", "TRAINING", "DEFAULT");
+        }
         return new ArrayList<>();
     }
 }

--- a/src/main/java/com/example/pvpenhancer/PvpEnhancerAPI.java
+++ b/src/main/java/com/example/pvpenhancer/PvpEnhancerAPI.java
@@ -1,0 +1,15 @@
+package com.example.pvpenhancer;
+
+import org.bukkit.entity.Player;
+
+public class PvpEnhancerAPI {
+    public static void setPlayerGamemode(Player player, String gamemode) {
+        PvPEnhancerPlugin plugin = PvPEnhancerPlugin.get();
+        if (plugin != null) {
+            IntelligentEngine engine = plugin.getEngineForPlayer(player);
+            if (engine != null) {
+                engine.setCurrentGamemode(gamemode.toUpperCase());
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `PvpEnhancerAPI` to allow external plugins to set a player's game mode context
- track current game mode in `IntelligentEngine` and scale knockback adjustments accordingly
- update `/pvp mode` command to target players and expose new modes with tab completion

## Testing
- `gradle build`

------
https://chatgpt.com/codex/tasks/task_e_689daa284e188324a320f6541ea14c78