### PR TITLE
feat: dynamic victim audio and remove cooldown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.2.0
+- Le son de dégât subi par la victime est désormais dynamique et suit le rythme du combo de l'attaquant.
+- Suppression complète de la mécanique d'attaque de balayage ("swoosh").
+- Le cooldown d'attaque post-1.9 a été entièrement désactivé pour une expérience 1.8 authentique.
+
 ## 2.1.0
 - Implémentation d'un système de feedback audio dynamique où la tonalité des sons d'impact augmente avec les combos.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PvpEnhancer
 
-Version **2.1.0**
+Version **2.2.0**
 
 PvpEnhancer provides adaptive, context-aware knockback powered by an intelligent engine with contextual impact physics for Spigot/Paper 1.21 servers.
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins { java }
 group = "com.example"
-version = "2.1.0"
+version = "2.2.0"
 
 repositories {
   maven("https://hub.spigotmc.org/nexus/content/repositories/snapshots/")

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -42,6 +42,7 @@ ensure-hit-damage:
 feel:
   hit-sound: ENTITY_PLAYER_ATTACK_STRONG
   victim-sound: ENTITY_PLAYER_HURT
+  override-vanilla-sounds: true
   particles: CRIT
   combo-actionbar: false
   dynamic-audio:

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: PvPEnhancer
 main: com.example.pvpenhancer.PvPEnhancerPlugin
-version: 2.1.0
+version: 2.2.0
 api-version: "1.21"
 description: PvP adaptatif et par joueur basé sur l'IA avec Résonance Rythmique pour Spigot/Paper 1.21
 


### PR DESCRIPTION
## Summary
- add option to override vanilla hurt sounds and play combo-based victim audio
- cancel sweep attack damage and lift attack speed for instant hits
- bump project to version 2.2.0

## Testing
- `gradle build`

------
https://chatgpt.com/codex/tasks/task_e_689e0c2bb35c8324baf2ab6f32fc4646